### PR TITLE
Update to k8s 1.26

### DIFF
--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -17,7 +17,7 @@ DOCKER_CMD ?= docker
 ## KIND:setup
 
 # https://hub.docker.com/r/kindest/node/tags
-KIND_NODE_VERSION ?= v1.24.4
+KIND_NODE_VERSION ?= v1.26.6
 KIND_IMAGE ?= docker.io/kindest/node:$(KIND_NODE_VERSION)
 KIND_CMD ?= go run sigs.k8s.io/kind
 KIND_KUBECONFIG ?= $(kind_dir)/kind-kubeconfig-$(KIND_NODE_VERSION)

--- a/kind/kind.mk
+++ b/kind/kind.mk
@@ -45,6 +45,7 @@ $(KIND_KUBECONFIG): $(kind_bin)
 		--name $(KIND_CLUSTER) \
 		--image $(KIND_IMAGE) \
 		--config kind/config.yaml
+	$(kind_bin) get kubeconfig --name $(KIND_CLUSTER) > $(kind_dir)/kind-config
 	@kubectl version
 	@kubectl cluster-info
 	@kubectl config use-context kind-$(KIND_CLUSTER)


### PR DESCRIPTION
Also write an additional kubeconfig without the version string in it. This way we have a stable path for the kubeconfig and we don't have to change all our launch configs when we update the k8s version.