### PR TITLE
Don't use paths for Alertmanager and Prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ $(prometheus_sentinel): kind-setup-ingress
 		--values prometheus/values.yaml \
 		prometheus-community/kube-prometheus-stack
 	kubectl -n prometheus-system wait --for condition=Available deployment/kube-prometheus-kube-prome-operator --timeout 120s
-	@echo -e "***\n*** Installed Prometheus in http://127.0.0.1.nip.io:8088/prometheus/ and AlertManager in http://127.0.0.1.nip.io:8088/alertmanager/.\n***"
+	@echo -e "***\n*** Installed Prometheus in http://prometheus.127.0.0.1.nip.io:8088/ and AlertManager in http://alertmanager.127.0.0.1.nip.io:8088/.\n***"
 	@touch $@
 
 load-comp-image: ## Load the appcat-comp image if it exists

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ The kind cluster features an ingress controller, that listens on `:8088`.
 
 Currently following apps are configured to use the ingress:
 
-- Promethues: http://127.0.0.1.nip.io:8088/prometheus/
-- Alertmanager: http://127.0.0.1.nip.io:8088/alertmanager/
+- Promethues: http://prometheus.127.0.0.1.nip.io:8088/
+- Alertmanager: http://alertmanager.127.0.0.1.nip.io:8088/
 - Minio: http://minio.127.0.0.1.nip.io:8088/
 - [Komoplane](https://github.com/komodorio/komoplane) (make komoplane-setup): http://komoplane.127.0.0.1.nip.io:8088/
 

--- a/prometheus/values.yaml
+++ b/prometheus/values.yaml
@@ -12,18 +12,13 @@ grafana:
   enabled: false
 
 alertmanager:
-  alertmanagerSpec:
-    routePrefix: /alertmanager/
   ingress:
     enabled: true
     hosts:
-      - 127.0.0.1.nip.io
-    paths:
-      - /alertmanager/
+      - alertmanager.127.0.0.1.nip.io
 
 prometheus:
   prometheusSpec:
-    routePrefix: /prometheus/
     # these will cause Prometheus to search in all namespaces
     serviceMonitorSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false
@@ -31,9 +26,7 @@ prometheus:
   ingress:
     enabled: true
     hosts:
-      - 127.0.0.1.nip.io
-    paths:
-      - /prometheus/
+      - prometheus.127.0.0.1.nip.io
 
 # See https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics
 kube-state-metrics:


### PR DESCRIPTION
This makes connecting to Prometheus and Alertmanager a lot easier.

Lens is not able to handle subpaths for Prometheus. Also the paths for Prometheus and Alertmanager are now aligned to other tools as well.