### PR TITLE
Add initial vcluster support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,15 @@ lint: ## All-in-one linting
 crossplane-setup: $(crossplane_sentinel) ## Install local Kubernetes cluster and install Crossplane
 
 $(crossplane_sentinel): export KUBECONFIG = $(KIND_KUBECONFIG)
-$(crossplane_sentinel): kind-setup csi-host-path-setup load-comp-image
+$(crossplane_sentinel): kind-setup csi-host-path-setup vcluster-setup
 	helm repo add crossplane https://charts.crossplane.io/stable --force-update
+	$(vcluster_bin) connect controlplane --namespace vcluster
 	helm upgrade --install crossplane --create-namespace --namespace syn-crossplane crossplane/crossplane \
 	--set "args[0]='--debug'" \
 	--set "args[1]='--enable-environment-configs'" \
 	--set "args[2]='--enable-usages'" \
 	--wait
+	$(vcluster_bin) disconnect
 	@touch $@
 
 stackgres-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
@@ -132,6 +134,7 @@ $(prometheus_sentinel): kind-setup-ingress
 load-comp-image: ## Load the appcat-comp image if it exists
 	[[ "$$(docker images -q ghcr.io/vshn/appcat 2> /dev/null)" != "" ]] && kind load docker-image --name kindev ghcr.io/vshn/appcat || true
 
+.PHONY: csi-host-path-setup
 csi-host-path-setup: $(csi_sentinel) ## Setup csi-driver-host-path and set as default, this provider supports resizing
 
 $(csi_sentinel): export KUBECONFIG = $(KIND_KUBECONFIG)
@@ -173,3 +176,18 @@ unset-default-sc:
 	for sc in $$(kubectl get sc -o name) ; do \
 		kubectl patch $$sc -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'; \
 	done
+
+.PHONY: install-vcluster-bin
+install-vcluster-bin: $(vcluster_bin)
+
+$(vcluster_bin): export GOOS = $(shell go env GOOS)
+$(vcluster_bin): export GOARCH = $(shell go env GOARCH)
+$(vcluster_bin): export GOBIN = $(go_bin)
+$(vcluster_bin): | $(go_bin)
+	go install github.com/loft-sh/vcluster/cmd/vclusterctl@latest
+
+
+.PHONY: vcluster-setup
+vcluster-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+vcluster-setup: install-vcluster-bin
+	$(vcluster_bin) create controlplane --namespace vcluster --connect=false || true

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -23,3 +23,8 @@ KIND_IMAGE ?= docker.io/kindest/node:$(KIND_NODE_VERSION)
 KIND_CMD ?= go run sigs.k8s.io/kind
 KIND_KUBECONFIG ?= $(kind_dir)/kind-kubeconfig-$(KIND_NODE_VERSION)
 KIND_CLUSTER ?= $(PROJECT_NAME)
+
+
+## VCLUSTER
+vcluster_bin = $(go_bin)/vclusterctl
+

--- a/README.md
+++ b/README.md
@@ -45,6 +45,33 @@ mc alias set localnip http://minio.127.0.0.1.nip.io:8088 minioadmin minioadmin
 
 Minio console access: http://minio-gui.127.0.0.1.nip.io:8088
 
+## Vcluster
+
+The `make crossplane-setup` target will install Crossplane into a vcluster. This will simulate clusters where the control-plane and service clusters are split up.
+
+### How to use it in make
+
+If you need to install something in the control cluster in make, you can do it like this:
+
+```make
+.PHONY: app-setup
+app-setup:
+  $(vcluster_bin) connect controlplane --namespace vcluster
+  $install what you need
+  $(vcluster_bin) disconnect
+```
+
+### Access vcluster
+
+If you need access to the vcluster from outside make (for example, when applying the AppCat component or other things). Export the kind config and then:
+
+```bash
+kubectl config get-contexts
+# get the vcluster context
+# it's the one starting with vcluster_*
+kubectl config use-context vcluster_*...
+```
+
 ## Integration into other projects
 
 kindev is intended to be used by Crossplane providers as a developement and test environment. It can be tied into other projects via a git submodule.

--- a/kind/kind.mk
+++ b/kind/kind.mk
@@ -45,7 +45,7 @@ $(KIND_KUBECONFIG): $(kind_bin)
 		--name $(KIND_CLUSTER) \
 		--image $(KIND_IMAGE) \
 		--config kind/config.yaml
-	$(kind_bin) get kubeconfig --name $(KIND_CLUSTER) > $(kind_dir)/kind-config
+	ln -s $(KIND_KUBECONFIG) $(kind_dir)/kind-config
 	@kubectl version
 	@kubectl cluster-info
 	@kubectl config use-context kind-$(KIND_CLUSTER)


### PR DESCRIPTION
This will help with developing for splitted clusters, where crossplane and the services are not on the same clusters.