### PR TITLE
Fix `kind-setup-ingress`

### DIFF
--- a/kind/kind.mk
+++ b/kind/kind.mk
@@ -28,7 +28,7 @@ kind-setup-ingress: kind-setup ## Install NGINX as ingress controller onto kind 
 	kubectl -n ingress-nginx wait --for condition=Ready pods -l app.kubernetes.io/component=controller --timeout 180s
 	# We need to restart nginx, because it can't properly find the endpoints otherwise...
 	kubectl -n ingress-nginx rollout restart deployment ingress-nginx-controller
-	kubectl -n ingress-nginx wait --for condition=Ready pods -l app.kubernetes.io/component=controller --timeout 180s
+	kubectl -n ingress-nginx wait --for=condition=Available deployment/ingress-nginx-controller --timeout=180s
 
 .PHONY: kind-load-image
 # We fix the arch to linux/amd64 since kind runs in amd64 even on Mac/arm.


### PR DESCRIPTION
Awaiting the controller pods right after `rollout restart ...` causes kubectl to report that it couldn't find a controller pod, causing `make` to fail:
```bash
...
kubectl -n ingress-nginx wait --for condition=Ready pods -l app.kubernetes.io/component=controller --timeout 180s
pod/ingress-nginx-controller-7c586bb6f4-hfg59 condition met
Error from server (NotFound): pods "ingress-nginx-controller-7b886f65c9-xw4lv" not found
make: *** [kind/kind.mk:31: kind-setup-ingress] Error 1
```

Awaiting the deployment instead of the pod fixes this.