### PR TITLE
Locked image tag for vcluster control plane to specific version

### DIFF
--- a/vclusterconfig/values.yaml
+++ b/vclusterconfig/values.yaml
@@ -1,5 +1,8 @@
 # Vcluster uses sqlite by default and basically just dies with our dev env
 controlPlane:
+  statefulSet:
+    image:
+      tag: 0.27.0
   proxy:
     extraSANs:
     - vcluster.127.0.0.1.nip.io


### PR DESCRIPTION
Due to an issue with the latest version of vcluster, the image tag has to be configured in order for the vcluster installation not to fail (see https://github.com/loft-sh/vcluster/issues/3087)