### PR TITLE
Add namespace cnpg-system to NetPol

### DIFF
--- a/netpols/netpol-mirroring.yaml
+++ b/netpols/netpol-mirroring.yaml
@@ -37,6 +37,9 @@ spec:
           - namespaceSelector:
               matchLabels:
                 kubernetes.io/metadata.name: ingress-nginx
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: cnpg-system
       podSelector: {}
       policyTypes:
       - Ingress


### PR DESCRIPTION
Required so that the CNPG operator can communicate with cluster objects in instance namespaces.