### PR TITLE
Changed k8up cleanup repository to alpine kubectl

### DIFF
--- a/k8up/values.yaml
+++ b/k8up/values.yaml
@@ -2,3 +2,6 @@ metrics:
   serviceMonitor:
     enabled: true
     scrapeInterval: 10s
+cleanup:
+  repository: alpine/kubectl
+


### PR DESCRIPTION
- Because of Bitnami EOL of the kubectl image, which prevents k8up from getting ready, the alpine kubectl image is used